### PR TITLE
Fixes for node-datachannel

### DIFF
--- a/benchmark/run-measurement-at-latency.sh
+++ b/benchmark/run-measurement-at-latency.sh
@@ -22,7 +22,7 @@ lnemdown="./node_modules/@streamr/lnem/bin/lnem-down"
 $lnemup -n 2 -l $quarterdelay
 
 sudo sysctl -w net.core.rmem_max=67108864
-sudo sysctl -w net.core.rmem_max=67108864
+sudo sysctl -w net.core.wmem_max=67108864
 
 sudo ip netns exec blue1 netserver -4 &
 


### PR DESCRIPTION
Same enhancements as https://github.com/streamr-dev/node-datachannel-performance-diagnostics/pull/2 for node-datachannel benchmark:
- Remove STUN server to shorten connection time
- Increase SCTP buffer size to 64 MB
- Reduce message size to 65535

Also fixes a typo preventing maximum socket buffer size to be set correctly.