### PR TITLE
Update node-datachannel to v0.1.11

### DIFF
--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -48,9 +48,9 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node-datachannel": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.10.tgz",
-      "integrity": "sha512-q8iD3VUbY1xws5OFiPukS/G4twrekTmQNI/cRK0F3K5wwMffM2PUgkmL+/6DrPYTh7+QM35+evS8+k+83Z/yTQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.11.tgz",
+      "integrity": "sha512-ziTWePzHO4VnbRZ0iQNhNsUw1ge89iQj8xS1MKZgiTrnK0OT8vkfTsxOm+9tCOcZCYqjrBuGRNlYi/yfZugEpw==",
       "requires": {
         "prebuild-install": "^5.3.6"
       },

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -20,7 +20,7 @@
     "@streamr/lnem": "latest",
     "@types/node": "^14.14.33",
     "@types/ws": "^7.4.0",
-    "node-datachannel": "^0.1.10",
+    "node-datachannel": "^0.1.11",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3",
     "ws": "^7.4.4"


### PR DESCRIPTION
This PR updates node-datachannel to v0.1.11 to disable SCTP CRC32 validation.